### PR TITLE
Add exception handling to integrity errors caused by importing.

### DIFF
--- a/import.py
+++ b/import.py
@@ -36,6 +36,7 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'evething.settings'
 import django
 django.setup()
 from django.db import connections
+from django.db.utils import IntegrityError
 
 from thing.models import *  # NOPEP8
 
@@ -376,7 +377,11 @@ class Importer:
             added += 1
 
         if new:
-            ItemGroup.objects.bulk_create(new)
+            try:
+                ItemGroup.objects.bulk_create(new)
+            except IntegrityError, e:
+                print e.message
+                
 
         return added
 
@@ -451,7 +456,10 @@ class Importer:
             added += 1
 
         if new:
-            Item.objects.bulk_create(new)
+            try:
+                Item.objects.bulk_create(new)
+            except IntegrityError, e:
+                print e.message
 
         return added
 
@@ -536,7 +544,10 @@ class Importer:
             added += 1
 
         if new:
-            Implant.objects.bulk_create(new)
+            try:
+                Implant.objects.bulk_create(new)
+            except IntegrityError, e:
+                print e.message
 
         return added
 
@@ -600,7 +611,10 @@ class Importer:
         # than trying to work out what has changed for every single blueprint
         if new:
             BlueprintComponent.objects.all().delete()
-            BlueprintComponent.objects.bulk_create(new)
+            try:
+                BlueprintComponent.objects.bulk_create(new)
+            except IntegrityError, e:
+                print e.message
 
         # Products!
         new = []
@@ -619,7 +633,10 @@ class Importer:
         # than trying to work out what has changed for every single blueprint
         if new:
             BlueprintProduct.objects.all().delete()
-            BlueprintProduct.objects.bulk_create(new)
+            try:
+                BlueprintProduct.objects.bulk_create(new)
+            except IntegrityError, e:
+                print e.message
 
         return added
 
@@ -706,7 +723,10 @@ class Importer:
             added += 1
 
         if new:
-            Skill.objects.bulk_create(new)
+            try:
+                Skill.objects.bulk_create(new)
+            except IntegrityError, e:
+                print e.message
 
         return added
 


### PR DESCRIPTION
The EVE SDE from Fuzzwork has integrity problems. For example, there is no invCategory ID=1, yet invGroup ID=1 and 2 reference a categoryID of 1.

I have not verified if these integrity problems are also present in the MSSQL original from CCP.

These problems cause the import to fail:

```
=> Region: 100 (0.02s)
=> Constellation: 1120 (0.07s)
=> System: 8035 (0.32s)
=> Station: 5185 (0.33s)
=> MarketGroup: 1943 (13.61s)
=> ItemCategory: 28 (0.00s)
=> ItemGroup:
Traceback (most recent call last):
  File "import.py", line 884, in <module>
    importer.import_all()
  File "import.py", line 115, in import_all
    time_func('ItemGroup', self.import_itemgroup)
  File "import.py", line 97, in time_func
    added = f()
  File "import.py", line 379, in import_itemgroup
    ItemGroup.objects.bulk_create(new)
  File "/usr/local/lib/python2.7/site-packages/django/db/models/manager.py", line 92, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/db/models/query.py", line 409, in bulk_create
    self._batched_insert(objs_without_pk, fields, batch_size)
  File "/usr/local/lib/python2.7/site-packages/django/db/transaction.py", line 339, in __exit__
    connection.commit()
  File "/usr/local/lib/python2.7/site-packages/django/db/backends/__init__.py", line 176, in commit
    self._commit()
  File "/usr/local/lib/python2.7/site-packages/django/db/backends/__init__.py", line 145, in _commit
    return self.connection.commit()
  File "/usr/local/lib/python2.7/site-packages/django/db/utils.py", line 94, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/usr/local/lib/python2.7/site-packages/django/db/backends/__init__.py", line 145, in _commit
    return self.connection.commit()
django.db.utils.IntegrityError: insert or update on table "thing_itemgroup" violates foreign key constraint "thing_ite_category_id_4b574cdc6d918316_fk_thing_itemcategory_id"
DETAIL:  Key (category_id)=(1) is not present in table "thing_itemcategory".
```

To allow a successful import, this branch adds exception handling to the imports. I felt this was the most appropriate solution. The integrity errors are printed but do not indicate a problem, so a possible improvement to this branch is to NOT print the errors, or print them in a friendlier fashion.
